### PR TITLE
On load, set cwd to package root.

### DIFF
--- a/glfw31-gl21-cube/cube.go
+++ b/glfw31-gl21-cube/cube.go
@@ -6,6 +6,7 @@
 package main
 
 import (
+	"go/build"
 	"image"
 	"image/draw"
 	_ "image/png"
@@ -61,7 +62,7 @@ func main() {
 func newTexture(file string) uint32 {
 	imgFile, err := os.Open(file)
 	if err != nil {
-		panic(err)
+		log.Fatalf("texture %q not found on disk: %v\n", file, err)
 	}
 	img, _, err := image.Decode(imgFile)
 	if err != nil {
@@ -201,4 +202,27 @@ func drawScene() {
 	gl.Vertex3f(-1, 1, -1)
 
 	gl.End()
+}
+
+// Set the working directory to the root of Go package, so that its assets can be accessed.
+func init() {
+	dir, err := importPathToDir("github.com/go-gl/examples/glfw31-gl21-cube")
+	if err != nil {
+		log.Fatalln("Unable to find Go package in your GOPATH, it's needed to load assets:", err)
+	}
+	err = os.Chdir(dir)
+	if err != nil {
+		log.Panicln("os.Chdir:", err)
+	}
+}
+
+// importPathToDir resolves the absolute path from importPath.
+// There doesn't need to be a valid Go package inside that import path,
+// but the directory must exist.
+func importPathToDir(importPath string) (string, error) {
+	p, err := build.Import(importPath, "", build.FindOnly)
+	if err != nil {
+		return "", err
+	}
+	return p.Dir, nil
 }


### PR DESCRIPTION
This allows both examples to work even if running from a different
directory.

Also improve error messages when assets are not successfully found on
disk, to make them more friendly.

Fixes #50.