### PR TITLE
glfw31-gl41core-cube: Use gl.Strs.

### DIFF
--- a/glfw31-gl41core-cube/cube.go
+++ b/glfw31-gl41core-cube/cube.go
@@ -177,8 +177,9 @@ func newProgram(vertexShaderSource, fragmentShaderSource string) (uint32, error)
 func compileShader(source string, shaderType uint32) (uint32, error) {
 	shader := gl.CreateShader(shaderType)
 
-	csource := gl.Str(source)
-	gl.ShaderSource(shader, 1, &csource, nil)
+	csources, free := gl.Strs(source)
+	gl.ShaderSource(shader, 1, csources, nil)
+	free()
 	gl.CompileShader(shader)
 
 	var status int32


### PR DESCRIPTION
Use new `gl.Strs` from go-gl/gl#44.

It's not strictly required for this minimal example to run in Go 1.6, but it's a good practice, and will serve as a canonical usage example.

/cc @slimsag